### PR TITLE
Append the script to the body

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,21 @@
 module.exports = load
 
-function load (src, cb) {
-  var head = document.head || document.getElementsByTagName('head')[0]
+function load (src, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
+
+  var headOrBody
+  if (opts.body) {
+    headOrBody = document.body || document.getElementsByTagName('body')[0]
+  } else {
+    headOrBody = document.head || document.getElementsByTagName('head')[0]
+  }
   var script = document.createElement('script')
 
   script.type = 'text/javascript'
-  script.async = true
+  script.async = opts.async !== false
   script.src = src
 
   if (cb) {
@@ -19,5 +29,5 @@ function load (src, cb) {
     }
   }
 
-  head.appendChild(script)
+  headOrBody.appendChild(script)
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -6,12 +6,26 @@ window.log = function (msg) {
   lastMessage = msg
 }
 
-test('success', function (t) {
-  t.plan(2)
+test('success head', function (t) {
+  t.plan(3)
 
+  var headChildren = document.head.children.length
   load('test/lib/hello.js', function (err) {
     t.error(err)
     t.equal(lastMessage, 'Hello world')
+    t.equal(document.head.children.length, headChildren + 1)
+    lastMessage = undefined
+  })
+})
+
+test('success body', function (t) {
+  t.plan(3)
+
+  var bodyChildren = document.body.children.length
+  load('test/lib/hello.js', { body: true }, function (err) {
+    t.error(err)
+    t.equal(lastMessage, 'Hello world')
+    t.equal(document.body.children.length, bodyChildren + 1)
     lastMessage = undefined
   })
 })


### PR DESCRIPTION
Sometimes it is useful to append the script at the end of the `body` and not in the `head`, this pr adds this feature.
Eg:
```js
load('test/lib/hello.js', { body: true }, (err) => {
  if (err) console.log(err)
})
```
Bonus: As it works in load-script, now `async` is configurable, but the default option is always true.
```js
load('test/lib/hello.js', { body: true, async: false }, (err) => {
  if (err) console.log(err)
})
```

Cheers! :)